### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ An MCP server that enables searching for Rust crates and their documentation fro
 
 English | [日本語](./README_JA.md)
 
+<a href="https://glama.ai/mcp/servers/@nuskey8/docs-rs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nuskey8/docs-rs-mcp/badge" alt="docs.rs MCP server" />
+</a>
+
 ## Overview
 
 docs.rs MCP is an MCP server that searches the Rust crate documentation site [docs.rs](https://docs.rs). By using this, AI Agents can search for required crates and obtain the latest documentation as needed.


### PR DESCRIPTION
This PR adds a badge for the [docs.rs MCP](https://glama.ai/mcp/servers/@nuskey8/docs-rs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nuskey8/docs-rs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nuskey8/docs-rs-mcp/badge" alt="docs.rs MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.